### PR TITLE
render registration when registration failed and set up devise japanese

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -43,9 +43,10 @@ class Users::RegistrationsController < Devise::RegistrationsController
         respond_with resource, location: after_inactive_sign_up_path_for(resource)
       end
     else
+      render action: :registration
       clean_up_passwords resource
       set_minimum_password_length
-      respond_with resource
+      # respond_with resource, location: after_failed_sign_up_path_for(resource)
     end
     # if @user.save
     #   redirect_to signup_done_path
@@ -68,6 +69,10 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   def after_sign_up_path_for(resource)
     signup_done_path
+  end
+
+  def after_failed_sign_up_path_for(resource)
+    signup_registration_path
   end
 
 end

--- a/app/views/devise/registrations/registration.html.haml
+++ b/app/views/devise/registrations/registration.html.haml
@@ -29,6 +29,7 @@
   %main.single-main
     .signup-panel
       %h2.signup-panel__head 会員情報入力
+      = devise_error_messages!
       .signup-panel__inner
         = form_for(@user, url: signup_sms_confirmation_path , html: { id:"form", method: :post}) do |f|
           .form-group

--- a/app/views/devise/shared/_links.html.haml
+++ b/app/views/devise/shared/_links.html.haml
@@ -2,7 +2,7 @@
   = link_to "Log in", new_session_path(resource_name)
   %br/
 - if devise_mapping.registerable? && controller_name != 'registrations'
-  = link_to "Sign up", new_registration_path(resource_name)
+  = link_to "Sign up", signup_registration_path(resource_name)
   %br/
 - if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations'
   = link_to "Forgot your password?", new_password_path(resource_name)

--- a/config/locales/devise.js.yml
+++ b/config/locales/devise.js.yml
@@ -1,0 +1,66 @@
+ja:
+  devise:
+    confirmations:
+      confirmed: 'アカウントを登録しました。'
+      send_instructions: 'アカウントの有効化について数分以内にメールでご連絡します。'
+      send_paranoid_instructions: "あなたのメールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。"
+    failure:
+      already_authenticated: 'すでにログインしています。'
+      inactive: 'アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。'
+      invalid: "%{authentication_keys} もしくはパスワードが不正です。"
+      locked: 'あなたのアカウントは凍結されています。'
+      last_attempt: 'あなたのアカウントが凍結される前に、複数回の操作がおこなわれています。'
+      not_found_in_database: "%{authentication_keys} もしくはパスワードが不正です。"
+      timeout: 'セッションがタイムアウトしました。もう一度ログインしてください。'
+      unauthenticated: 'アカウント登録もしくはログインしてください。'
+      unconfirmed: 'メールアドレスの本人確認が必要です。'
+    mailer:
+      confirmation_instructions:
+        subject: 'アカウントの有効化について'
+      reset_password_instructions:
+        subject: 'パスワードの再設定について'
+      unlock_instructions:
+        subject: 'アカウントの凍結解除について'
+      password_change:
+        subject: 'パスワードの変更について'
+    omniauth_callbacks:
+      failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
+      success: "%{kind} アカウントによる認証に成功しました。"
+    passwords:
+      no_token: "このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。"
+      send_instructions: 'パスワードの再設定について数分以内にメールでご連絡いたします。'
+      send_paranoid_instructions: "あなたのメールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。"
+      updated: 'パスワードが正しく変更されました。'
+      updated_not_active: 'パスワードが正しく変更されました。'
+    registrations:
+      destroyed: 'アカウントを削除しました。またのご利用をお待ちしております。'
+      signed_up: 'アカウント登録が完了しました。'
+      signed_up_but_inactive: 'ログインするためには、アカウントを有効化してください。'
+      signed_up_but_locked: 'アカウントが凍結されているためログインできません。'
+      signed_up_but_unconfirmed: '本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。'
+      update_needs_confirmation: 'アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。'
+      updated: 'アカウント情報を変更しました。'
+    sessions:
+      signed_in: 'ログインしました。'
+      signed_out: 'ログアウトしました。'
+      already_signed_out: '既にログアウト済みです。'
+    unlocks:
+      send_instructions: 'アカウントの凍結解除方法を数分以内にメールでご連絡します。'
+      send_paranoid_instructions: 'アカウントが見つかった場合、アカウントの凍結解除方法を数分以内にメールでご連絡します。'
+      unlocked: 'アカウントを凍結解除しました。'
+  errors:
+    messages:
+      already_confirmed: 'は既に登録済みです。ログインしてください。'
+      confirmation_period_expired: "の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。"
+      expired: 'の有効期限が切れました。新しくリクエストしてください。'
+      not_found: 'は見つかりませんでした。'
+      not_locked: 'は凍結されていません。'
+      not_saved:
+        one: "エラーが発生したため %{resource} は保存されませんでした:"
+        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした:"
+      taken: "は既に使用されています。"
+      blank: "が入力されていません。"
+      too_short: "は%{count}文字以上に設定して下さい。"
+      too_long: "は%{count}文字以下に設定して下さい。"
+      invalid: "は有効でありません。"
+      confirmation: "が内容とあっていません。"


### PR DESCRIPTION
# what
新規登録失敗時の遷移先の変更
デバイスのエラーメッセージ日本語化

# why
ユーザー登録失敗時の再登録を適切に促すため